### PR TITLE
Home report reload

### DIFF
--- a/src/components/reports/Summary.vue
+++ b/src/components/reports/Summary.vue
@@ -2,6 +2,18 @@
   <div class="summary">
     <h4>{{ title }}</h4>
 
+    <div class="top-right-toolbar">
+      <v-btn
+        class="mr-1"
+        text
+        icon
+        :disabled="loading"
+        @click="$emit('reload')"
+      >
+        <v-icon>refresh</v-icon>
+      </v-btn>
+    </div>
+
     <v-progress-circular
       :rotate="-90"
       :value="progress"
@@ -42,6 +54,10 @@ export default {
     approximate: {
       type: Boolean,
       default: true
+    },
+    loading: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
@@ -106,6 +122,13 @@ h4 {
 }
 .summary {
   text-align: center;
+  position: relative;
+
+  .top-right-toolbar {
+    position: absolute;
+    top: 0;
+    right: 0;
+  }
 }
 .hours {
   font-size: 8em;

--- a/src/store/modules/pomodoro/actions.js
+++ b/src/store/modules/pomodoro/actions.js
@@ -20,6 +20,13 @@ export default {
       },
       { root: true }
     )
+    await dispatch(
+      'timeEntry/loadToday',
+      {},
+      {
+        root: true
+      }
+    )
   },
   openModal({ commit }, issueId) {
     commit('setIssue', issueId || null)

--- a/src/store/modules/timer/actions.js
+++ b/src/store/modules/timer/actions.js
@@ -101,6 +101,13 @@ export default {
     await dispatch('systemTray/removeTimerControl', id, {
       root: true
     })
+    await dispatch(
+      'timeEntry/loadToday',
+      {},
+      {
+        root: true
+      }
+    )
     commit('delete', timer.id)
   },
   async recordFixedTime(
@@ -124,6 +131,13 @@ export default {
         title: `Tracked ${hours} hours on issue ${issueId}`
       },
       { root: true }
+    )
+    await dispatch(
+      'timeEntry/loadToday',
+      {},
+      {
+        root: true
+      }
     )
   },
   async discard({ commit, state, dispatch }, id) {

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -26,7 +26,13 @@
       <paused-timer :timer="timer" @stop="saveTimer(timer)" />
     </div>
 
-    <summary-report :entries="dailyEntries" type="day" :approximate="false" />
+    <summary-report
+      :entries="dailyEntries"
+      type="day"
+      :approximate="false"
+      :loading="loading"
+      @reload="loadTodayEntries()"
+    />
 
     <save-timer
       v-model="modalSaveTimer"


### PR DESCRIPTION
Add a reload button to "daily worked hours" in dashboard view.

![tracker-reload](https://user-images.githubusercontent.com/8782994/63516016-6eb21000-c4ec-11e9-9087-72c7dc2265f5.png)

this should also update this widget when a timer (or pomodoro) is saved.